### PR TITLE
Add GetAuxNetDevicesFromPci function

### DIFF
--- a/sriovnet.go
+++ b/sriovnet.go
@@ -25,8 +25,9 @@ const (
 )
 
 var (
-	virtFnRe     = regexp.MustCompile(`virtfn(\d+)`)
-	pciAddressRe = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f].[0-7]$`)
+	virtFnRe          = regexp.MustCompile(`virtfn(\d+)`)
+	pciAddressRe      = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f].[0-7]$`)
+	auxiliaryDeviceRe = regexp.MustCompile(`^(\S+\.){2}\d+$`)
 )
 
 type VfObj struct {

--- a/sriovnet_aux.go
+++ b/sriovnet_aux.go
@@ -87,3 +87,25 @@ func GetUplinkRepresentorFromAux(auxDev string) (string, error) {
 
 	return GetUplinkRepresentor(pfPci)
 }
+
+// GetAuxNetDevicesFromPci returns a list of auxiliary devices names for the specified PCI network device
+func GetAuxNetDevicesFromPci(pciAddr string) ([]string, error) {
+	baseDev := filepath.Join(PciSysDir, pciAddr)
+	// ensure that "net" folder exists, meaning it is network PCI device
+	if _, err := utilfs.Fs.Stat(filepath.Join(baseDev, "net")); err != nil {
+		return nil, err
+	}
+
+	files, err := utilfs.Fs.ReadDir(baseDev)
+	if err != nil {
+		return nil, err
+	}
+
+	auxDevs := make([]string, 0)
+	for _, file := range files {
+		if auxiliaryDeviceRe.MatchString(file.Name()) {
+			auxDevs = append(auxDevs, file.Name())
+		}
+	}
+	return auxDevs, nil
+}


### PR DESCRIPTION
Function returns a list of auxiliary device names of provided PCI address if it is a networking device. This ensured by checking that "net" folder exists.

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>