### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: | $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run lint tests
 
 .PHONY: test tests
 test: ; $(info  running unit tests...) ## Run unit tests
-	$Q go test ./...
+	$Q go test -race ./...
 
 tests: test lint ; ## Run all tests
 


### PR DESCRIPTION
This pull request enables race detection in unit tests by modifying the Makefile. The test configuration is updated to include the '-race' flag, allowing thorough race detection during testing. 

Race detection can help identifying potential data race conditions, which can lead to hard-to-debug issues in concurrent code. By enabling race detection in our unit tests, we can detect and address these race conditions, ensuring the reliability and stability of our code. (for further reference view: https://go.dev/doc/articles/race_detector)