### PR TITLE
Fix: build on 32bit system

### DIFF
--- a/sriovnet_aux.go
+++ b/sriovnet_aux.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	u32Mask = 0xffffffff
+	u32Mask uint32 = 0xffffffff
 )
 
 // GetNetDeviceFromAux gets auxiliary device name (e.g 'mlx5_core.sf.2') and
@@ -134,7 +134,7 @@ func GetAuxSFDevByPciAndSFIndex(pciAddress string, sfIndex uint32) (string, erro
 			continue
 		}
 
-		if uint32(idx&u32Mask) == sfIndex {
+		if uint32(idx)&u32Mask == sfIndex {
 			return dev, nil
 		}
 	}


### PR DESCRIPTION
build with GOARCH=386 fails with error:

$ GOARCH=386 go build ./...
./sriovnet_aux.go:137:17: u32Mask (untyped int constant 4294967295) overflows int

fix this by modifying u32Mask to be uint32 and proper casting.